### PR TITLE
fix: checkout 단계에서 submodules을 켜도록 deploy.yml 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout (with submodules)
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
@@ -28,7 +31,12 @@ jobs:
           extended: true
 
       - name: Build
-        run: hugo --minify
+        run: |
+          hugo --minify
+          echo "== public/ top =="
+          ls -la public | head -n 200
+          echo "== must have public/index.html =="
+          test -f public/index.html
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- hugo-theme-stack을 git submodule로 가져왔기 때문에 받아오지 못하는 오류임을 확인 후 Checkout 설정 변경

## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #5 
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
  
## 📌 추가 사항  
- <추가로 고려해야 할 사항>
