### PR TITLE
fix: hugo.toml avatar 이미지 등록 방식 변경

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,9 +17,13 @@ enableRobotsTXT = true
   favicon = "/favicon.ico"
 
   [params.sidebar]
-    avatar = "img/avatar.png" 
     emoji = "💻"
     subtitle = "CS · Algorithms · JavaScript"
+    
+    [params.sidebar.avatar]
+      enabled = true
+      local = true
+      src = "img/avatar.png"
 
   [params.article]
     math = false


### PR DESCRIPTION
## 📝 변경 사항  
[//]: # (이 PR에서 수행된 변경 사항에 대해 설명)  
- hogo.toml의 params.sidebar가 아닌 params.sidebar.avatar에 적용가능한 옵션임을 확인하고 수정
  
## 🔍 관련 이슈  
- 이 PR이 해결하는 이슈: #9
  
## ✅ 테스트 결과  
- [x] 기능 테스트 완료  
- [x] 버그 테스트 완료  
